### PR TITLE
Rethink size prediction

### DIFF
--- a/src/Contracts/FileContract.php
+++ b/src/Contracts/FileContract.php
@@ -20,8 +20,6 @@ interface FileContract
 
     public function getOptions(): FileOptions;
 
-    public function predictZipDataSize(ArchiveOptions $options): int;
-
     public function getReadableStream(): StreamInterface;
 
     public function getWritableStream(): StreamInterface;

--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -43,11 +43,20 @@ class ZipStream extends BaseZipStream implements Responsable
     /** @var Collection */
     protected $meta;
 
+    /** @var bool */
+    protected $calculateOnly = false;
+
+    /** @var int */
+    protected $calculated = 0;
+
+    /** @var int */
+    protected $predictedSize = 0;
+
     /**
      * @param ArchiveOptions $archiveOptions
-     * @param FileOptions $fileOptions
+     * @param FileOptions    $fileOptions
      */
-    public function __construct(ArchiveOptions $archiveOptions, FileOptions $fileOptions)
+    public function __construct( ArchiveOptions $archiveOptions, FileOptions $fileOptions )
     {
         parent::__construct(null, $archiveOptions);
 
@@ -59,11 +68,11 @@ class ZipStream extends BaseZipStream implements Responsable
     /**
      * @param string $name
      *
-     * @param array $files
+     * @param array  $files
      *
      * @return ZipStream
      */
-    public function create(?string $name = null, array $files = [])
+    public function create( ?string $name = null, array $files = [] )
     {
         $zip = (new self($this->archiveOptions, $this->fileOptions))->setName($name);
 
@@ -83,7 +92,7 @@ class ZipStream extends BaseZipStream implements Responsable
      *
      * @return $this
      */
-    public function setName(string $name)
+    public function setName( string $name )
     {
         $this->output_name = $name;
 
@@ -92,11 +101,11 @@ class ZipStream extends BaseZipStream implements Responsable
 
     /**
      * @param string|FileContract $source
-     * @param string|null $zipPath
+     * @param string|null         $zipPath
      *
      * @return $this
      */
-    public function add($source, ?string $zipPath = null)
+    public function add( $source, ?string $zipPath = null )
     {
         if (!$source instanceof FileContract) {
             $source = File::make($source, $zipPath);
@@ -107,26 +116,22 @@ class ZipStream extends BaseZipStream implements Responsable
             $this->queue->put($source->getZipPath(), $source);
         }
 
+        $this->clear();
+
         return $this;
     }
 
     /**
      * Explicitly add raw content instead of from file on disk
      *
-     * @param $content
+     * @param        $content
      * @param string $zipPath
      *
      * @return $this
      */
-    public function addRaw($content, string $zipPath)
+    public function addRaw( $content, string $zipPath )
     {
-        $file = new TempFile($content, $zipPath);
-
-        if (!$this->queue->has($file->getZipPath())) {
-            $this->queue->put($file->getZipPath(), $file);
-        }
-
-        return $this;
+        return $this->add(new TempFile($content, $zipPath));
     }
 
     /**
@@ -134,7 +139,7 @@ class ZipStream extends BaseZipStream implements Responsable
      *
      * @return $this
      */
-    public function setMeta(array $meta)
+    public function setMeta( array $meta )
     {
         $this->meta = collect($meta);
 
@@ -159,15 +164,11 @@ class ZipStream extends BaseZipStream implements Responsable
     {
         event(new ZipStreaming($this));
 
-        $this->queue->each(function (File $file) {
-            $this->addFileFromPsr7Stream($file->getZipPath(), $file->getReadableStream(), $file->getOptions());
-            $file->getReadableStream()->close();
-        });
+        $this->queue->map->toZipStreamFile($this)->each->process();
 
-        $estimation = false;
-        if ($this->canPredictZipSize()) {
-            $estimation = $this->predictZipSize();
-        }
+        $predicted = $this->canPredictZipSize()
+            ? $this->predictZipSize()
+            : false;
 
         $this->finish();
         $this->getOutputStream()->close();
@@ -178,8 +179,8 @@ class ZipStream extends BaseZipStream implements Responsable
 
         event(new ZipStreamed($this));
 
-        if ($estimation && $estimation != $this->getFinalSize()) {
-            event(new ZipSizePredictionFailed($this, $estimation, $this->getFinalSize()));
+        if ($predicted && $predicted != $this->getFinalSize()) {
+            event(new ZipSizePredictionFailed($this, $predicted, $this->getFinalSize()));
         }
 
         return $this->getFinalSize();
@@ -200,7 +201,7 @@ class ZipStream extends BaseZipStream implements Responsable
      *
      * @return StreamedResponse
      */
-    public function toResponse($request)
+    public function toResponse( $request )
     {
         return $this->response();
     }
@@ -244,7 +245,7 @@ class ZipStream extends BaseZipStream implements Responsable
      *
      * @return ZipStream
      */
-    public function cache($output)
+    public function cache( $output )
     {
         if (!$output instanceof FileContract) {
             $output = File::make($output);
@@ -273,7 +274,7 @@ class ZipStream extends BaseZipStream implements Responsable
      * @return int
      * @throws OverflowException
      */
-    public function saveTo($output): int
+    public function saveTo( $output ): int
     {
         if (!$output instanceof FileContract) {
             $output = File::make(Str::finish($output, "/") . $this->getName());
@@ -287,8 +288,14 @@ class ZipStream extends BaseZipStream implements Responsable
     /**
      * @param string $str
      */
-    public function send(string $str): void
+    public function send( string $str ): void
     {
+        if ($this->calculateOnly) {
+            $this->calculated += strlen($str);
+
+            return;
+        }
+
         $this->getOutputStream()->write($str);
 
         if ($this->cacheOutputStream) {
@@ -308,8 +315,6 @@ class ZipStream extends BaseZipStream implements Responsable
     }
 
     /**
-     * Stack Overflow FTW! http://stackoverflow.com/a/19380600/660694
-     *
      * @return int
      */
     public function predictZipSize(): int
@@ -317,23 +322,22 @@ class ZipStream extends BaseZipStream implements Responsable
         if (!$this->canPredictZipSize()) {
             return 0;
         }
-        $commentLength = strlen($this->opt->getComment());
-        $size = $this->queue->sum->predictZipDataSize($this->opt);
 
-        // ZIP64 has an additional directory entry
-        if ($size >= 0xFFFFFFFF) {
-            $size += 96;
-
-            if (!$this->opt->isZeroHeader()) {
-                $size += 20;
-            }
+        if ($this->predictedSize > 0) {
+            return $this->predictedSize;
         }
 
-        // end of central directory record
-        // 4 + 2 + 2 + 2 + 2 + 4 + 4 + 2 + comment
-        $size += 22 + $commentLength;
+        $this->calculated = 0;
+        $this->calculateOnly = true;
 
-        return $size;
+        $this->queue->map->toZipStreamFile($this)->each->calculate();
+        $this->finish();
+
+        $this->predictedSize = $this->queue->sum->getFilesize() + $this->calculated;
+
+        $this->calculateOnly = false;
+
+        return $this->predictedSize;
     }
 
     /**
@@ -346,5 +350,16 @@ class ZipStream extends BaseZipStream implements Responsable
             . $this->getName()
             . serialize($this->getMeta()->sort()->toArray())
         );
+    }
+
+    /**
+     *
+     */
+    protected function clear(): void
+    {
+        parent::clear();
+
+        $this->predictedSize = 0;
+        $this->opt = $this->archiveOptions;
     }
 }

--- a/src/ZipStreamFile.php
+++ b/src/ZipStreamFile.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace STS\ZipStream;
+
+use STS\ZipStream\Models\File;
+use ZipStream\Bigint;
+use ZipStream\ZipStream;
+
+/**
+ *
+ */
+class ZipStreamFile extends \ZipStream\File
+{
+    /** @var File */
+    protected $file;
+
+    /**
+     * ZipStreamFile constructor.
+     *
+     * @param ZipStream $zip
+     * @param File      $file
+     */
+    public function __construct( ZipStream $zip, File $file )
+    {
+        $this->file = $file;
+
+        $opt = $file->getOptions();
+        $opt->defaultTo($zip->opt);
+
+        $this->zlen = new Bigint();
+        $this->len = new Bigint();
+
+        parent::__construct($zip, $file->getZipPath(), $opt);
+    }
+
+    /**
+     *
+     */
+    public function process( )
+    {
+        $this->processStreamWithZeroHeader($this->file->getReadableStream());
+        $this->file->getReadableStream()->close();
+    }
+
+    /**
+     * @throws \ZipStream\Exception\EncodingException
+     */
+    public function calculate()
+    {
+        $this->bits |= self::BIT_ZERO_HEADER;
+        $this->addFileHeader();
+
+        $this->len = BigInt::init($this->file->getFilesize());
+        $this->zlen = Bigint::init($this->file->getFilesize());
+
+        $this->addFileFooter();
+    }
+}

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -48,9 +48,10 @@ class ZipTest extends TestCase
         file_put_contents("/tmp/test1.txt", "this is the first test file for test run $testrun");
         file_put_contents("/tmp/test2.txt", "this is the second test file for test run $testrun");
         exec('dd if=/dev/zero count=5120 bs=1048576 >/tmp/bigfile.txt');
+        exec('dd if=/dev/zero count=1024 bs=1048576 >/tmp/medfile.txt');
 
         /** @var ZipStream $zip */
-        $zip = Zip::create("my.zip", ["/tmp/test1.txt", "/tmp/test2.txt", "/tmp/bigfile.txt"]);
+        $zip = Zip::create("my.zip", ["/tmp/test1.txt", "/tmp/test2.txt", "/tmp/bigfile.txt", "/tmp/medfile.txt"]);
         $sizePrediction = $zip->predictZipSize();
         $zip->saveTo("/tmp");
 


### PR DESCRIPTION
Trying to predict the final zip filesize has been a pain, and I still haven't nailed Zip64 prediction.

This PR attempts to build a fake zip, skip adding the actual file contents, and see what the generated zip records/headers are. That gives us the zip size information we need upfront, without having to reverse engineer everything.

https://github.com/stechstudio/laravel-zipstream/blob/64139ecabd939747e2e2bca16a45830fc1633f78/src/ZipStream.php#L331-L338

https://github.com/stechstudio/laravel-zipstream/blob/64139ecabd939747e2e2bca16a45830fc1633f78/src/ZipStreamFile.php#L48-L57

I'm not 100% confident in this approach yet, but all tests are passing and so far it seems to be far more resilient than previous attempts.