### PR TITLE
Turn on zip64 only when needed

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -6,8 +6,6 @@
 return [
     // Default options for our archives
     'archive' => [
-        'zip64' => env('ZIPSTREAM_ENABLE_ZIP64', true),
-
         'predict' => env('ZIPSTREAM_PREDICT_SIZE', true)
     ],
 

--- a/src/ZipStreamServiceProvider.php
+++ b/src/ZipStreamServiceProvider.php
@@ -55,7 +55,6 @@ class ZipStreamServiceProvider extends ServiceProvider
     protected function buildArchiveOptions(array $config)
     {
         return tap(new ArchiveOptions(), function(ArchiveOptions $options) use($config) {
-            $options->setEnableZip64($config['zip64']);
             $options->setZeroHeader(true);
         });
     }

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -29,17 +29,18 @@ class ZipTest extends TestCase
         file_put_contents("/tmp/test2.txt", "this is the second test file for test run $testrun");
 
         /** @var ZipStream $zip */
-        $zip = Zip::create("my.zip", ["/tmp/test1.txt", "/tmp/test2.txt"]);
+        $zip = Zip::create("small.zip", ["/tmp/test1.txt", "/tmp/test2.txt"]);
         $sizePrediction = $zip->predictZipSize();
         $zip->saveTo("/tmp");
 
-        $this->assertTrue(file_exists("/tmp/my.zip"));
-        $this->assertEquals($sizePrediction, filesize("/tmp/my.zip"));
+        $this->assertFalse($zip->opt->isEnableZip64());
+        $this->assertTrue(file_exists("/tmp/small.zip"));
+        $this->assertEquals($sizePrediction, filesize("/tmp/small.zip"));
 
-        $z = zip_open("/tmp/my.zip");
+        $z = zip_open("/tmp/small.zip");
         $this->assertEquals("this is the first test file for test run $testrun", zip_entry_read(zip_read($z)));
 
-        unlink("/tmp/my.zip");
+        unlink("/tmp/small.zip");
     }
 
     public function testSaveZip64Output()
@@ -51,16 +52,17 @@ class ZipTest extends TestCase
         exec('dd if=/dev/zero count=1024 bs=1048576 >/tmp/medfile.txt');
 
         /** @var ZipStream $zip */
-        $zip = Zip::create("my.zip", ["/tmp/test1.txt", "/tmp/test2.txt", "/tmp/bigfile.txt", "/tmp/medfile.txt"]);
+        $zip = Zip::create("large.zip", ["/tmp/test1.txt", "/tmp/test2.txt", "/tmp/bigfile.txt", "/tmp/medfile.txt"]);
         $sizePrediction = $zip->predictZipSize();
         $zip->saveTo("/tmp");
 
-        $this->assertTrue(file_exists("/tmp/my.zip"));
-        $this->assertEquals($sizePrediction, filesize("/tmp/my.zip"));
+        $this->assertTrue($zip->opt->isEnableZip64());
+        $this->assertTrue(file_exists("/tmp/large.zip"));
+        $this->assertEquals($sizePrediction, filesize("/tmp/large.zip"));
 
-        $z = zip_open("/tmp/my.zip");
+        $z = zip_open("/tmp/large.zip");
         $this->assertEquals("this is the first test file for test run $testrun", zip_entry_read(zip_read($z)));
 
-        unlink("/tmp/my.zip");
+        unlink("/tmp/large.zip");
     }
 }


### PR DESCRIPTION
Mac's Finder cannot open Zip64 zips at all. I'd like to ensure that we do _not_ use the Zip64 option unless absolutely necessary. That way the default Finder can open the majority of zips (under ~4.2GB). When a larger zip is generated, the Zip64 flag is now automatically enabled. Mac users will simply have to use a 3rd-party unzipper (like [Keka](https://www.keka.io/)). I'm ok with that.