### PR TITLE
Better S3 client creation

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -10,16 +10,19 @@ return [
     ],
 
     // Default options for files added
-    'file' => [
+    'file'    => [
         'method' => env('ZIPSTREAM_FILE_METHOD', 'store'),
 
         'deflate' => env('ZIPSTREAM_FILE_DEFLATE'),
     ],
 
     // AWS configs for S3 files
-    'aws' => [
-        'key' => env('AWS_ACCESS_KEY_ID'),
-        'secret' => env('AWS_SECRET_ACCESS_KEY'),
-        'region' => env('ZIPSTREAM_AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))
+    'aws'     => [
+        'credentials' => [
+            'key'    => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY')
+        ],
+        'version'     => '2006-03-01',
+        'region'      => env('ZIPSTREAM_AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))
     ]
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -22,7 +22,7 @@ return [
             'key'    => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY')
         ],
-        'version'     => '2006-03-01',
+        'version'     => 'latest',
         'region'      => env('ZIPSTREAM_AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))
     ]
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -18,11 +18,13 @@ return [
 
     // AWS configs for S3 files
     'aws'     => [
-        'credentials' => [
+        'credentials'             => [
             'key'    => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY')
         ],
-        'version'     => 'latest',
-        'region'      => env('ZIPSTREAM_AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))
+        'version'                 => 'latest',
+        'endpoint'                => env('AWS_ENDPOINT'),
+        'use_path_style_endpoint' => env('ZIPSTREAM_AWS_PATH_STYLE_ENDPOINT', false),
+        'region'                  => env('ZIPSTREAM_AWS_REGION', env('AWS_DEFAULT_REGION', 'us-east-1'))
     ]
 ];

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -150,6 +150,13 @@ abstract class File implements FileContract
         return $this->filesize;
     }
 
+    public function setFilesize(int $filesize)
+    {
+        $this->filesize = $filesize;
+
+        return $this;
+    }
+
     /**
      * @return int
      */

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -53,14 +53,7 @@ class S3File extends File
     public function getS3Client(): S3Client
     {
         if (!$this->client) {
-            $this->client = new Aws\S3\S3Client([
-                'region'      => $this->getRegion(),
-                'version'     => '2006-03-01',
-                'credentials' => [
-                    'key'    => config('zipstream.aws.key'),
-                    'secret' => config('zipstream.aws.secret')
-                ]
-            ]);
+            $this->client = app('zipstream.s3client');
         }
 
         return $this->client;

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -17,18 +17,6 @@ class S3File extends File
     protected $client;
 
     /**
-     * @param string $region
-     *
-     * @return $this
-     */
-    public function setRegion(?string $region = null)
-    {
-        $this->region = $region;
-
-        return $this;
-    }
-
-    /**
      * @return int
      */
     public function calculateFilesize(): int
@@ -40,11 +28,15 @@ class S3File extends File
     }
 
     /**
-     * @return string
+     * @param S3Client $client
+     *
+     * @return mixed
      */
-    public function getRegion(): string
+    public function setS3Client(S3Client $client)
     {
-        return $this->region ?? config('zipstream.aws.region');
+        $this->client = $client;
+
+        return $this;
     }
 
     /**

--- a/src/ZipStreamServiceProvider.php
+++ b/src/ZipStreamServiceProvider.php
@@ -41,7 +41,13 @@ class ZipStreamServiceProvider extends ServiceProvider
         });
 
         $this->app->bind('zipstream.s3client', function($app) {
-            return new \Aws\S3\S3Client($app['config']->get('zipstream.aws'));
+            $config = $app['config']->get('zipstream.aws');
+
+            if(!count(array_filter($config['credentials']))) {
+                $config['credentials'] = false;
+            }
+
+            return new \Aws\S3\S3Client($config);
         });
     }
 

--- a/src/ZipStreamServiceProvider.php
+++ b/src/ZipStreamServiceProvider.php
@@ -41,7 +41,7 @@ class ZipStreamServiceProvider extends ServiceProvider
         });
 
         $this->app->bind('zipstream.s3client', function($app) {
-            return new Aws\S3\S3Client($app['config']->get('zipstream.aws'));
+            return new \Aws\S3\S3Client($app['config']->get('zipstream.aws'));
         });
     }
 

--- a/src/ZipStreamServiceProvider.php
+++ b/src/ZipStreamServiceProvider.php
@@ -39,6 +39,10 @@ class ZipStreamServiceProvider extends ServiceProvider
         $this->app->bind(ArchiveOptions::class, function($app) {
             return $this->buildArchiveOptions($app['config']->get('zipstream.archive'));
         });
+
+        $this->app->bind('zipstream.s3client', function($app) {
+            return new Aws\S3\S3Client($app['config']->get('zipstream.aws'));
+        });
     }
 
     /**
@@ -46,7 +50,7 @@ class ZipStreamServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [FileOptions::class, ArchiveOptions::class, 'zipstream'];
+        return [FileOptions::class, ArchiveOptions::class, 'zipstream', 'zipstream.s3client'];
     }
 
     /**

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -39,4 +39,12 @@ class FileTest extends TestCase
         $this->assertEquals("hi there", $file->getReadableStream()->getContents());
         $this->assertEquals("test.txt", $file->getZipPath());
     }
+
+    public function testSettingFilesize()
+    {
+        $file = new TempFile("hi there", "test.txt");
+        $file->setFilesize(12345);
+
+        $this->assertEquals(12345, $file->getFilesize());
+    }
 }


### PR DESCRIPTION
Instead of creating the S3 client directly in the S3File class, we'll now wire it up in the service provider. This way consumers can re-wire it up if they need to.

Additionally, this alters the config file structure just a bit, with the `aws` section matching the array structure passed to a new S3Client instance. This way consumers can publish the config file and directly control how the S3 client is created.﻿
