### PR TITLE
Update guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/support": "^5.6|^6.0|^7.0",
         "maennchen/zipstream-php": "^v2.0"
     },


### PR DESCRIPTION
Add support for ^7.0 of `guzzlehttp/guzzle`, the stream creation function has not changed so the ^6.0 constraint can remain.