### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/support": "^5.6|^6.0|^7.0|^8.0",
         "maennchen/zipstream-php": "^v2.0"

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -4,6 +4,7 @@ namespace STS\ZipStream\Tests;
 
 use STS\ZipStream\ZipStream;
 use Zip;
+use ZipArchive;
 use Orchestra\Testbench\TestCase;
 use STS\ZipStream\ZipStreamFacade;
 use STS\ZipStream\ZipStreamServiceProvider;
@@ -37,8 +38,9 @@ class ZipTest extends TestCase
         $this->assertTrue(file_exists("/tmp/small.zip"));
         $this->assertEquals($sizePrediction, filesize("/tmp/small.zip"));
 
-        $z = zip_open("/tmp/small.zip");
-        $this->assertEquals("this is the first test file for test run $testrun", zip_entry_read(zip_read($z)));
+		$z = new ZipArchive();
+        $z->open("/tmp/small.zip");
+        $this->assertEquals("this is the first test file for test run $testrun", $z->getFromIndex(0));
 
         unlink("/tmp/small.zip");
     }
@@ -60,8 +62,9 @@ class ZipTest extends TestCase
         $this->assertTrue(file_exists("/tmp/large.zip"));
         $this->assertEquals($sizePrediction, filesize("/tmp/large.zip"));
 
-        $z = zip_open("/tmp/large.zip");
-        $this->assertEquals("this is the first test file for test run $testrun", zip_entry_read(zip_read($z)));
+        $z = new ZipArchive();
+        $z->open("/tmp/large.zip");
+        $this->assertEquals("this is the first test file for test run $testrun", $z->getFromIndex(0));
 
         unlink("/tmp/large.zip");
     }


### PR DESCRIPTION
#35 

Update composer requirement and replace deprecated zip functions.

Credit to @michaeldnelson

Edit: Testet with PHP 8.0.0:
```
$ composer run test
> vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.0
Configuration: ./laravel-zipstream/phpunit.xml.dist

....5120+0 records in
5120+0 records out
5368709120 bytes transferred in 1.642410 secs (3268799976 bytes/sec)
.............................5120+0 records in
5120+0 records out
5368709120 bytes transferred in 1.621767 secs (3310407089 bytes/sec)
1024+0 records in
1024+0 records out
1073741824 bytes transferred in 0.346066 secs (3102708241 bytes/sec)
.                                34 / 34 (100%)

Time: 00:28.647, Memory: 20.00 MB

OK (34 tests, 76 assertions)

```