### PR TITLE
fix: use Laravel utilities for generating response

### DIFF
--- a/src/ZipStream.php
+++ b/src/ZipStream.php
@@ -5,6 +5,7 @@ namespace STS\ZipStream;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;
 use STS\ZipStream\Contracts\FileContract;
 use STS\ZipStream\Events\ZipSizePredictionFailed;
@@ -200,9 +201,9 @@ class ZipStream extends BaseZipStream implements Responsable
      */
     public function response(): StreamedResponse
     {
-        return new StreamedResponse(function () {
+        return Response::streamDownload(function () {
             $this->process();
-        }, 200, $this->getHeaders());
+        }, $this->getName(), $this->getHeaders());
     }
 
     /**


### PR DESCRIPTION
Closes #49.

This replaces the manual instantiation of `StreamResponse` with Laravel's own `Response::streamDownload()` method. This should solve the compatibilty issues I experienced with Livewire, as well as add some consistency with Laravel's own recommended method.