### PR TITLE
Option to skip zip path sanitization

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -14,6 +14,8 @@ return [
         'method' => env('ZIPSTREAM_FILE_METHOD', 'store'),
 
         'deflate' => env('ZIPSTREAM_FILE_DEFLATE'),
+
+        'sanitize' => env('ZIPSTREAM_FILE_SANITIZE', true)
     ],
 
     // AWS configs for S3 files

--- a/src/Models/File.php
+++ b/src/Models/File.php
@@ -104,13 +104,11 @@ abstract class File implements FileContract
      */
     public function getZipPath(): string
     {
-        return Str::ascii(
-            ltrim(
-                preg_replace('|/{2,}|', '/',
-                    $this->zipPath
-                ),
-                '/')
-        );
+        $path = ltrim(preg_replace('|/{2,}|', '/', $this->zipPath), '/');
+
+        return config('zipstream.file.sanitize')
+            ? Str::ascii($path)
+            : $path;
     }
 
     /**

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -7,9 +7,17 @@ use STS\ZipStream\Models\File;
 use STS\ZipStream\Models\LocalFile;
 use STS\ZipStream\Models\S3File;
 use STS\ZipStream\Models\TempFile;
+use STS\ZipStream\ZipStreamServiceProvider;
 
 class FileTest extends TestCase
 {
+    protected function getPackageProviders($app)
+    {
+        return [
+            ZipStreamServiceProvider::class,
+        ];
+    }
+
     public function testMake()
     {
         $this->assertInstanceOf(S3File::class, File::make('s3://bucket/key'));
@@ -55,5 +63,15 @@ class FileTest extends TestCase
         $file->setFilesize(12345);
 
         $this->assertEquals(12345, $file->getFilesize());
+    }
+
+    public function testSanitizeFilename()
+    {
+        // Default is to sanitize the filename
+        $file = new TempFile("hi there", "ϩtrÂͶğƎ♡.txt");
+        $this->assertEquals('trAg.txt', $file->getZipPath());
+
+        config(['zipstream.file.sanitize' => false]);
+        $this->assertEquals("ϩtrÂͶğƎ♡.txt", $file->getZipPath());
     }
 }


### PR DESCRIPTION
Introduces a new config option to control whether the zip path of a file is run through an ASCII filter or not. Default is true, in order to be backwards compatible.

Resolves #64.﻿
