### PR TITLE
Update calculateFilesize()

### DIFF
--- a/src/Models/HttpFile.php
+++ b/src/Models/HttpFile.php
@@ -19,8 +19,13 @@ class HttpFile extends File
     {
         $headers = $this->getHeaders();
 
+        if(is_array($headers[self::HEADER_CONTENT_LENGTH])){
+            return end($headers[self::HEADER_CONTENT_LENGTH]);
+        }
+
         return $headers[self::HEADER_CONTENT_LENGTH];
     }
+
 
     /**
      * @return StreamInterface


### PR DESCRIPTION
301 redirects seem to return an array of content-lengths, the first, I assume to be the size of the 301 response, and the second of the file being redirected to.  I updated the calculateFilesize() function to return the last element of the array if the content-length happens to be one.