### PR TITLE
doc: add description for filename sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ You might use an internal DB id for your cache name, so that the next time a use
 - `STS\ZipStream\Events\ZipStreamed`: Dispatched when a zip finishes streaming
 - `STS\ZipStream\Events\ZipSizePredictionFailed`: Fired if the predicted filesize doesn't match the final size. If you have filesize prediction enabled it's a good idea to listen for this event and log it, since that might mean the zip download failed or was corrupt for your user. 
 
+## Filename sanitization
+
+By default this package will try to translate any non-ascii character in filename or folder's name to ascii. For example, if your filename is `中文_にほんご_Ч_Ɯ_☺_someascii.txt`. It will become `__C___someascii.txt` by call Laravel's `Str::ascii($path)`.
+
+So if you want to use some special filename, you can disable this feature. You can do it by add below line to your `.env`:
+
+```env
+ZIPSTREAM_FILE_SANITIZE=false
+```
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE.md) for more information.


### PR DESCRIPTION
Hi, thanks for this useful package.
I encountered some problem during creating some file with special filename(out-of-ascii characters), and after some effort I figured out it's because configuration `config('zipstream.file.sanitize')`.
I notice it's not written in the readme, so I try write some description for filename sanitization to help others to avoid same problem with me.