### PR TITLE
Fix S3 Stream Misbehavior

### DIFF
--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -72,10 +72,9 @@ class S3File extends File
      */
     protected function buildReadableStream(): StreamInterface
     {
-        return $this->getS3Client()->getObject([
-            'Bucket' => $this->getBucket(),
-            'Key'    => $this->getKey()
-        ])->get('Body');
+        $this->getS3Client()->registerStreamWrapper();
+
+        return Utils::streamFor(fopen($this->getSource(), 'r'));
     }
 
     /**


### PR DESCRIPTION
The following downloads the entire file to `/tmp`.

```php
return $this->getS3Client()->getObject([
        'Bucket' => $this->getBucket(),
        'Key'    => $this->getKey()
])->get('Body');
```

Even though the `Body` implements `StreamInterface`, it's not just a pointer to a stream from S3. It's being fully downloaded to and then streamed back out from the VM's shared, rusty, spinning disk hard drive. In order to stream without first downloading the entire file, we need to [open a stream using `fopen`](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-stream-wrapper.html#downloading-data).

Downloading large files to `/tmp` before streaming to the client causes delays during the zip download in between those files. In the worst cases, these delays lead to server timeouts, or client timeouts that are reported as "network failures," causing the download to fail entirely.

@schmanks and I have been able to reproduce this issue in all three of our own internal usages of this package in ReproConnect, FileRocket, and Fetcher.