### PR TITLE
fix if there is no header content-length

### DIFF
--- a/src/Models/HttpFile.php
+++ b/src/Models/HttpFile.php
@@ -19,6 +19,10 @@ class HttpFile extends File
     {
         $headers = $this->getHeaders();
 
+        if (!array_key_exists(self::HEADER_CONTENT_LENGTH, $headers)) {
+            return false;
+        }
+
         if(is_array($headers[self::HEADER_CONTENT_LENGTH])){
             return end($headers[self::HEADER_CONTENT_LENGTH]);
         }


### PR DESCRIPTION
If for some reason there is no header `content-length`, then we crash into an error: `undefined array key`
The archive is created normally.