### PR TITLE
Fix key retrieval in S3File to support paths with hash signs

### DIFF
--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -64,7 +64,7 @@ class S3File extends File
      */
     public function getKey(): string
     {
-        return ltrim(parse_url($this->getSource(), PHP_URL_PATH), "/");
+        return ltrim(substr($this->getSource(), strlen('s3://'.$this->getBucket())), '/');
     }
 
     /**

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -57,6 +57,19 @@ class FileTest extends TestCase
         $this->assertEquals("test.txt", $file->getZipPath());
     }
 
+    public function testS3File()
+    {
+        $file = new S3File("s3://bucket/key");
+
+        $this->assertEquals('bucket', $file->getBucket());
+        $this->assertEquals('key', $file->getKey());
+
+        $file_with_fragment = new S3File("s3://bucket/key#afterhash");
+
+        $this->assertEquals('bucket', $file_with_fragment->getBucket());
+        $this->assertEquals('key#afterhash', $file_with_fragment->getKey());
+    }
+
     public function testSettingFilesize()
     {
         $file = new TempFile("hi there", "test.txt");


### PR DESCRIPTION
This PR modifies the `getKey` method in `S3File` to support paths with hash signs.

Right now, if we attempt to add an S3 file path that contains a hash sign (`#`), the `getKey` method returns an incorrect key:

```php
$file = File::make('s3://bucket/key#afterhash');
echo $file->getKey(); // Outputs 'key', but should be 'key#afterhash'
```

This then makes fetching the file from S3 fail, which can be surprising if we are checking for the file existence in S3 beforehand.

This bug occurs because the current `getKey` method only gets the path as parsed by `parse_url`, and doesn't include path fragments. (As far as I know, S3 does not have a concept of path fragments)

To fix this, we modify the `getKey` method to just take everything after the 's3://' prefix and the bucket name. This is inspired by [what Flysystem does in PathPrefixer](https://github.com/thephpleague/flysystem/blob/072735c56cc0da00e10716dd90d5a7f7b40b36be/src/PathPrefixer.php#L29-L33), which is what Laravel uses under the hood in its S3 adapter.

One assumption we make in this PR is that the source URL always has a leading `s3://`. We can theoretically create an S3File instance without a leading `s3://` as its source URL, but this would make fetching the file from S3 fail unless we overwrite the streaming logic, so I do not believe this is a breaking change.