### PR TITLE
Fix S3 filenames that include a hash

### DIFF
--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -17,10 +17,7 @@ class S3File extends File
 
     public function calculateFilesize(): int
     {
-        return $this->getS3Client()->headObject([
-            'Bucket' => $this->getBucket(),
-            'Key'    => $this->getKey()
-        ])->get('ContentLength');
+        return $this->getReadableStream()->getSize();
     }
 
     public function setS3Client(S3Client $client): self
@@ -37,18 +34,6 @@ class S3File extends File
         }
 
         return $this->client;
-    }
-
-    public function getBucket(): string
-    {
-        return parse_url($this->getSource(), PHP_URL_HOST);
-    }
-
-    public function getKey(): string
-    {
-        $s3AndBucketLength = strlen("s3://{$this->getBucket()}/");
-        $key = substr($this->getSource(), $s3AndBucketLength);
-        return ltrim($key);
     }
 
     protected function buildReadableStream(): StreamInterface

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -46,7 +46,9 @@ class S3File extends File
 
     public function getKey(): string
     {
-        return ltrim(parse_url($this->getSource(), PHP_URL_PATH), "/");
+        $s3AndBucketLength = strlen("s3://{$this->getBucket()}/");
+        $key = substr($this->getSource(), $s3AndBucketLength);
+        return ltrim($key);
     }
 
     protected function buildReadableStream(): StreamInterface

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -117,11 +117,4 @@ class FileTest extends TestCase
         $this->assertInstanceOf(S3File::class, $file);
         $this->assertEquals('s3://my-test-bucket/my-prefix/test.txt', $file->getSource());
     }
-
-    public function testS3HashFilename()
-    {
-        $file = S3File::make('s3://my-test-bucket/file with hash #.txt');
-        $this->assertEquals('file with hash #.txt', $file->getKey());
-        $this->assertEquals('my-test-bucket', $file->getBucket());
-    }
 }

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -117,4 +117,11 @@ class FileTest extends TestCase
         $this->assertInstanceOf(S3File::class, $file);
         $this->assertEquals('s3://my-test-bucket/my-prefix/test.txt', $file->getSource());
     }
+
+    public function testS3HashFilename()
+    {
+        $file = S3File::make('s3://my-test-bucket/file with hash #.txt');
+        $this->assertEquals('file with hash #.txt', $file->getKey());
+        $this->assertEquals('my-test-bucket', $file->getBucket());
+    }
 }


### PR DESCRIPTION
Ran into this when we switched to using Zip Stream recently, S3 filenames with a hash `#` were being truncated. The Laravel `Storage` facade handles hashes without issue.

Possible breaking changes I can think of with this PR:
1. Using `strlen("s3://{$this->getBucket()}/");` means that if anyone has a malformed S3 bucket string, this would fail in unexpected ways
2. If anyone was relying on the old behavior of `parse_url()`, this does change how S3 file paths are parsed