### PR TITLE
S3File: use dedicated temp stream to get size

### DIFF
--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -17,10 +17,9 @@ class S3File extends File
 
     public function calculateFilesize(): int
     {
-        // We use a separate and immediately discarded stream to get the file
-        // size to avoid prematurely caching the stream to be used for the
-        // actual file body fetching (which could expire depending on the
-        // number and size of files and the connection speeds).
+        // Use a separate, immediately discarded, stream to get the file size
+        // to avoid the main stream from being opened prematurely then timing
+        // out before the file contents can be streamed.
         $stream = $this->buildReadableStream();
         $size = $stream->getSize();
         $stream->close();

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -25,7 +25,11 @@ class S3File extends File
         // Since we don't hold a reference to this stream it will be
         // immediately discarded and the destructor automatically called (to
         // clean up the underlying descriptors).
-        return $this->buildReadableStream()->getSize();
+        $stream = $this->buildReadableStream();
+        $size = $stream->getSize();
+        $stream->close();
+
+        return $size;
     }
 
     public function setS3Client(S3Client $client): self

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -21,10 +21,6 @@ class S3File extends File
         // size to avoid prematurely caching the stream to be used for the
         // actual file body fetching (which could expire depending on the
         // number and size of files and the connection speeds).
-        //
-        // Since we don't hold a reference to this stream it will be
-        // immediately discarded and the destructor automatically called (to
-        // clean up the underlying descriptors).
         $stream = $this->buildReadableStream();
         $size = $stream->getSize();
         $stream->close();

--- a/src/Models/S3File.php
+++ b/src/Models/S3File.php
@@ -17,7 +17,15 @@ class S3File extends File
 
     public function calculateFilesize(): int
     {
-        return $this->getReadableStream()->getSize();
+        // We use a separate and immediately discarded stream to get the file
+        // size to avoid prematurely caching the stream to be used for the
+        // actual file body fetching (which could expire depending on the
+        // number and size of files and the connection speeds).
+        //
+        // Since we don't hold a reference to this stream it will be
+        // immediately discarded and the destructor automatically called (to
+        // clean up the underlying descriptors).
+        return $this->buildReadableStream()->getSize();
     }
 
     public function setS3Client(S3Client $client): self


### PR DESCRIPTION
In order to avoid prematurely creating and using our persistent connection which will be used by the `ZipStream` library to actually fetch the file contents, we here switch to a separate and immediately discarded stream to use to fetch the file size. This solution will not break the fix to the issue of filename parsing that https://github.com/stechstudio/laravel-zipstream/pull/121 resolved.

Fixes https://github.com/stechstudio/laravel-zipstream/issues/125.

-----

Test results:

```
PHPUnit 11.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.11
Configuration: /home/zmd/Code/laravel-zipstream/phpunit.xml.dist

...................                                               19 / 19 (100%)

Time: 00:03.432, Memory: 44.00 MB

OK (19 tests, 69 assertions)
```