### PR TITLE
Add FTP stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,35 @@ Zip::create("package.zip")
     ->addFromDisk("s3", "object.pdf", "Something.pdf");
 ```
 
-In this case the S3 client from the storage disk will be used. 
+In this case the S3 client from the storage disk will be used.
+
+## Support for FTP
+
+You can stream files from an FTP server into your zip. There's two ways to achieve this:
+
+### Add files from disk
+
+For this you will need to [configure an FTP disk.](https://laravel.com/docs/12.x/filesystem#ftp-driver-configuration)
+
+```php
+Zip::create('package.zip')
+    ->addFromDisk('ftp', 'object.pdf', 'Something.pdf');
+
+\\ OR
+
+$disk = Storage::disk('custom_ftp_disk');
+Zip::create('package.zip')
+    ->addFromDisk($disk, 'object.pdf', 'Something.pdf');
+```
+
+### Add files from a FTP URL
+
+Pass a valid [FTP URL](https://www.php.net/manual/en/wrappers.ftp.php) to add files from a custom URL:
+
+```php
+Zip::create('package.zip')
+    ->add('ftp://example.com/pub/file.txt', 'object.pdf', 'Something.pdf');
+```
 
 ## Specify your own filesizes
 

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,12 @@
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^3.28",
+        "league/flysystem-ftp": "^3.29",
         "orchestra/testbench": "^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^9.0|^10.0|^11.5.3"
+    },
+    "suggest": {
+        "league/flysystem-ftp": "Allows FTP support."
     },
     "autoload": {
         "psr-4": {

--- a/src/Models/FtpFile.php
+++ b/src/Models/FtpFile.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace STS\ZipStream\Models;
+
+use GuzzleHttp\Psr7\Utils;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Str;
+use Psr\Http\Message\StreamInterface;
+use STS\ZipStream\OutputStream;
+
+class FtpFile extends File
+{
+    protected FilesystemAdapter $disk;
+
+    public static function makeFromDisk($disk, string $source, ?string $zipPath = null): static
+    {
+        $config = $disk->getConfig();
+
+        $protocol = !empty($config['ssl']) ? 'ftps://' : 'ftp://';
+        $host     = $config['host'] ?? '';
+
+        $user = $config['username'] ?? null;
+        $pass = $config['password'] ?? '';
+        $userInfo = $user ? "$user:$pass@" : '';
+
+        $root = $config['root'] ?? '';
+        $root = $root ? Str::start($root, '/') : '';
+
+        return new static($protocol . $userInfo . $host . $root .'/'. $source, $zipPath);
+    }
+
+    public function canPredictZipDataSize(): bool
+    {
+        return true;
+    }
+
+    public function calculateFilesize(): int
+    {
+        return stat($this->source)['size'];
+    }
+
+    protected function buildReadableStream(): StreamInterface
+    {
+        return Utils::streamFor($this->getStream('rb'));
+    }
+
+    protected function buildWritableStream(): OutputStream
+    {
+        return new OutputStream($this->getStream('wb'));
+    }
+
+    /**
+     * @return resource
+     */
+    protected function getStream(string $mode)
+    {
+        return fopen($this->source, $mode, context: stream_context_create([
+            'ftp' => [
+                'overwrite' => true
+            ]
+        ]));
+    }
+}


### PR DESCRIPTION
Hi there! :wave: 

There was a need for FTP stream support in a project I'm working on, so I thought I'd upstream the work I've done.

As of now, I've only implemented support for `addFromDisk(...)`, `add('ftp://...')` is not currently supported, you need to have the disk configured in your `config/filesystems.php` file.

Let me know your thoughts.